### PR TITLE
fix(readme): correct usage command for fastmcp install

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This project uses the [uv](https://docs.astral.sh/uv/) package manager, a drop-i
 ### Usage
 You can install this server in [Claude Desktop](https://claude.ai/download) and interact with it right away by running:
 ```bash
-fastmcp install server.py
+fastmcp install claude desktop server.py
 ```
 
 Alternatively, you can test it with the MCP Inspector:


### PR DESCRIPTION
### Summary

This PR corrects the command in the README under the **Usage** section.

The original line:
`fastmcp install server.py
`
has been updated to:

`fastmcp install claude desktop server.py
`
to reflect the correct usage of the fastmcp CLI with Claude Desktop.

Thanks for the great project!